### PR TITLE
Fix an oversight in RSM that wasn't taking the available worker budge…

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -549,7 +549,8 @@ public class RenderSectionManager {
     private void submitSectionTasks(ChunkJobCollector collector, UploadResourceBudget uploadBudget, TaskQueueType queueType) {
         var taskList = this.taskLists.get(queueType);
 
-        while (!taskList.isEmpty() && (uploadBudget.isAvailable() || queueType.allowsUnlimitedUploadDuration())) {
+        // submit tasks as long as there's tasks available, the collector has worker thread budget, and there's enough upload budget left 
+        while (!taskList.isEmpty() && collector.hasBudgetRemaining() && (uploadBudget.isAvailable() || queueType.allowsUnlimitedUploadDuration())) {
             RenderSection section = taskList.poll();
 
             if (section == null) {


### PR DESCRIPTION
…t into account when scheduling tasks.

This caused too many tasks to be submitted, causing weird chunk loading patterns and unresponsive loading of chunks when moving rapidly.